### PR TITLE
Minify content tests, update dependencies

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -18,7 +18,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [18, 20, 22, 24]
+        node-version: [20, 22, 24]
 
     steps:
       - name: Clone repository

--- a/local_modules/simple-test-framework/package-lock.json
+++ b/local_modules/simple-test-framework/package-lock.json
@@ -11,8 +11,8 @@
         "run-simple-tests": "bin/run-tests.ts"
       },
       "devDependencies": {
-        "ts-node": "10",
-        "typescript": "3"
+        "ts-node": "10.9.2",
+        "typescript": "5.9.3"
       }
     },
     "node_modules/@cspotcode/source-map-support": {
@@ -197,17 +197,18 @@
       }
     },
     "node_modules/typescript": {
-      "version": "3.9.10",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.10.tgz",
-      "integrity": "sha512-w6fIxVE/H1PkLKcCPsFqKE7Kv7QUwhU8qQY2MueZXWx5cPZdwFupLgKK3vntcK98BtNHZtAF4LA/yl2a7k8R6Q==",
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
       },
       "engines": {
-        "node": ">=4.2.0"
+        "node": ">=14.17"
       }
     },
     "node_modules/undici-types": {
@@ -215,8 +216,7 @@
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.20.0.tgz",
       "integrity": "sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/v8-compile-cache-lib": {
       "version": "3.0.1",

--- a/local_modules/simple-test-framework/package.json
+++ b/local_modules/simple-test-framework/package.json
@@ -11,7 +11,7 @@
   },
   "devDependencies": {
     "ts-node": "10.9.2",
-    "typescript": "3.9.10"
+    "typescript": "5.9.3"
   },
   "private": true
 }

--- a/local_modules/simple-test-framework/src/index.d.ts
+++ b/local_modules/simple-test-framework/src/index.d.ts
@@ -1,4 +1,4 @@
-declare type TestFunction = () => void | Promise<void>;
+type TestFunction = () => void | Promise<void>;
 export declare const test: (name: string, fn: TestFunction) => void;
 export declare const describe: (name: string, fn: () => void) => void;
 export declare const beforeEach: (fn: TestFunction) => void;
@@ -7,7 +7,12 @@ export declare function expect<T>(actual: T): {
     toBe: (expected: T) => void;
     toEqual: (expected: T) => void;
     toBeUndefined: () => void;
+    toContain: (expected: any) => void;
+    not: {
+        toContain: (expected: any) => void;
+        toBe: (expected: T) => void;
+    };
 };
 export declare function runTestFile(filePath: string): Promise<void>;
-export declare function findAndRunTests(dir: string): Promise<void>;
+export declare const testsRunner: (cwd: string) => Promise<void>;
 export {};

--- a/local_modules/simple-test-framework/src/index.ts
+++ b/local_modules/simple-test-framework/src/index.ts
@@ -104,6 +104,39 @@ export function expect<T>(actual: T) {
                 throw new Error(`Expected undefined, but got ${actual}`);
             }
         },
+        toContain: (expected: any) => {
+            if (Array.isArray(actual)) {
+                if (!actual.includes(expected)) {
+                    throw new Error(`Expected array to contain ${expected}, but it did not.`);
+                }
+            } else if (typeof actual === 'string') {
+                if (!actual.includes(expected)) {
+                    throw new Error(`Expected string to contain "${expected}", but it did not.`);
+                }
+            } else {
+                throw new Error(`Expected toContain to be used with an array or string, but got ${typeof actual}`);
+            }
+        },
+        not: {
+            toContain: (expected: any) => {
+                if (Array.isArray(actual)) {
+                    if (actual.includes(expected)) {
+                        throw new Error(`Expected array NOT to contain ${expected}, but it did.`);
+                    }
+                } else if (typeof actual === 'string') {
+                    if (actual.includes(expected)) {
+                        throw new Error(`Expected string NOT to contain "${expected}", but it did.`);
+                    }
+                } else {
+                    throw new Error(`Expected not.toContain to be used with an array or string, but got ${typeof actual}`);
+                }
+            },
+            toBe: (expected: T) => {
+                if (actual === expected) {
+                    throw new Error(`Expected not to be ${expected}, but it was.`);
+                }
+            }
+        }
     };
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "@types/node": "24.10.1",
         "@types/twig": "1.12.17",
         "simple-test-framework": "file:local_modules/simple-test-framework",
+        "ts-node": "10.9.2",
         "typescript": "5.9.3"
       },
       "engines": {
@@ -33,21 +34,7 @@
       },
       "devDependencies": {
         "ts-node": "10.9.2",
-        "typescript": "3.9.10"
-      }
-    },
-    "local_modules/simple-test-framework/node_modules/typescript": {
-      "version": "3.9.10",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.10.tgz",
-      "integrity": "sha512-w6fIxVE/H1PkLKcCPsFqKE7Kv7QUwhU8qQY2MueZXWx5cPZdwFupLgKK3vntcK98BtNHZtAF4LA/yl2a7k8R6Q==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=4.2.0"
+        "typescript": "5.9.3"
       }
     },
     "node_modules/@babel/runtime": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,6 @@
         "tateru-cli": "dist/tateru-cli.js"
       },
       "devDependencies": {
-        "@types/html-minifier-next": "2.1.1",
         "@types/node": "24.10.1",
         "@types/twig": "1.12.17",
         "simple-test-framework": "file:local_modules/simple-test-framework",
@@ -73,28 +72,6 @@
         "node": ">=12"
       }
     },
-    "node_modules/@jridgewell/gen-mapping": {
-      "version": "0.3.13",
-      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
-      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jridgewell/sourcemap-codec": "^1.5.0",
-        "@jridgewell/trace-mapping": "^0.3.24"
-      }
-    },
-    "node_modules/@jridgewell/gen-mapping/node_modules/@jridgewell/trace-mapping": {
-      "version": "0.3.31",
-      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
-      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jridgewell/resolve-uri": "^3.1.0",
-        "@jridgewell/sourcemap-codec": "^1.4.14"
-      }
-    },
     "node_modules/@jridgewell/resolve-uri": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
@@ -103,28 +80,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=6.0.0"
-      }
-    },
-    "node_modules/@jridgewell/source-map": {
-      "version": "0.3.11",
-      "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.11.tgz",
-      "integrity": "sha512-ZMp1V8ZFcPG5dIWnQLr3NSI1MiCU7UETdS/A0G8V/XWHvJv3ZsFqutJn1Y5RPmAPX6F3BiE397OqveU/9NCuIA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jridgewell/gen-mapping": "^0.3.5",
-        "@jridgewell/trace-mapping": "^0.3.25"
-      }
-    },
-    "node_modules/@jridgewell/source-map/node_modules/@jridgewell/trace-mapping": {
-      "version": "0.3.31",
-      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
-      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jridgewell/resolve-uri": "^3.1.0",
-        "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
     "node_modules/@jridgewell/sourcemap-codec": {
@@ -252,29 +207,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@types/clean-css": {
-      "version": "4.2.11",
-      "resolved": "https://registry.npmjs.org/@types/clean-css/-/clean-css-4.2.11.tgz",
-      "integrity": "sha512-Y8n81lQVTAfP2TOdtJJEsCoYl1AnOkqDqMvXb9/7pfgZZ7r8YrEyurrAvAoAjHOGXKRybay+5CsExqIH6liccw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*",
-        "source-map": "^0.6.0"
-      }
-    },
-    "node_modules/@types/html-minifier-next": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@types/html-minifier-next/-/html-minifier-next-2.1.1.tgz",
-      "integrity": "sha512-zdffvBzlDsCk3vz2b1V1/CHMWaGF9hQUeqoM/j/rP3sCpZkcRq5s1YwWJThd6laqnezJ9gQONc9QYPPqQXV5+w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/clean-css": "*",
-        "@types/relateurl": "*",
-        "terser": "*"
-      }
-    },
     "node_modules/@types/node": {
       "version": "24.10.1",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-24.10.1.tgz",
@@ -285,13 +217,6 @@
       "dependencies": {
         "undici-types": "~7.16.0"
       }
-    },
-    "node_modules/@types/relateurl": {
-      "version": "0.2.33",
-      "resolved": "https://registry.npmjs.org/@types/relateurl/-/relateurl-0.2.33.tgz",
-      "integrity": "sha512-bTQCKsVbIdzLqZhLkF5fcJQreE4y1ro4DIyVrlDNSCJRRwHhB8Z+4zXXa8jN6eDvc2HbRsEYgbvrnGvi54EpSw==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/@types/twig": {
       "version": "1.12.17",
@@ -348,20 +273,6 @@
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
       }
-    },
-    "node_modules/buffer-from": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
-      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/commander": {
-      "version": "2.20.3",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/concat-map": {
       "version": "0.0.1",
@@ -424,46 +335,6 @@
     "node_modules/simple-test-framework": {
       "resolved": "local_modules/simple-test-framework",
       "link": true
-    },
-    "node_modules/source-map": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/source-map-support": {
-      "version": "0.5.21",
-      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
-      "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "buffer-from": "^1.0.0",
-        "source-map": "^0.6.0"
-      }
-    },
-    "node_modules/terser": {
-      "version": "5.44.1",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-5.44.1.tgz",
-      "integrity": "sha512-t/R3R/n0MSwnnazuPpPNVO60LX0SKL45pyl9YlvxIdkH0Of7D5qM2EVe+yASRIlY5pZ73nclYJfNANGWPwFDZw==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "@jridgewell/source-map": "^0.3.3",
-        "acorn": "^8.15.0",
-        "commander": "^2.20.0",
-        "source-map-support": "~0.5.20"
-      },
-      "bin": {
-        "terser": "bin/terser"
-      },
-      "engines": {
-        "node": ">=10"
-      }
     },
     "node_modules/ts-node": {
       "version": "10.9.2",

--- a/package.json
+++ b/package.json
@@ -59,7 +59,6 @@
     "twig": "1.17.1"
   },
   "devDependencies": {
-    "@types/html-minifier-next": "2.1.1",
     "@types/node": "24.10.1",
     "@types/twig": "1.12.17",
     "simple-test-framework": "file:local_modules/simple-test-framework",

--- a/package.json
+++ b/package.json
@@ -62,10 +62,11 @@
     "@types/node": "24.10.1",
     "@types/twig": "1.12.17",
     "simple-test-framework": "file:local_modules/simple-test-framework",
+    "ts-node": "10.9.2",
     "typescript": "5.9.3"
   },
   "engines": {
-    "node": ">=18.0.0"
+    "node": ">=20.0.0"
   },
   "types": "./types.d.ts",
   "preferGlobal": true

--- a/src/minify/minifyContents.spec.ts
+++ b/src/minify/minifyContents.spec.ts
@@ -1,0 +1,63 @@
+import { describe, test, expect } from 'simple-test-framework';
+import { minifyContents } from './minifyContents';
+
+describe('minifyContents', () => {
+    test('should minify HTML content', async () => {
+        const html = `
+            <!DOCTYPE html>
+            <html lang="en">
+            <head>
+                <meta charset="UTF-8">
+                <title>Test</title>
+                <style>
+                    body {
+                        background-color: #fff;
+                    }
+                </style>
+            </head>
+            <body>
+                <h1>  Hello   World  </h1>
+                <script>
+                    console.log(  "test"  );
+                </script>
+            </body>
+            </html>
+        `;
+
+        const minified = await minifyContents(html, 'html');
+
+        // Basic checks for minification
+        expect(minified.includes('  Hello   World  ')).toBe(false);
+        expect(minified.includes('Hello World')).toBe(true);
+        expect(minified.includes('\n')).toBe(false);
+        expect(minified.includes('<!doctype html>')).toBe(true); // @minify-html usually lowercases doctype
+    });
+
+    test('should return original content if fileType is not html', async () => {
+        const css = `
+            body {
+                color: red;
+            }
+        `;
+        const result = await minifyContents(css, 'css');
+        expect(result).toBe(css);
+    });
+
+    test('should handle fileType case insensitively', async () => {
+        const html = '<div>  test  </div>';
+        const minified = await minifyContents(html, 'HTML');
+        expect(minified).toBe('<div>test</div>');
+    });
+
+    test('should handle fileType with whitespace', async () => {
+        const html = '<div>  test  </div>';
+        const minified = await minifyContents(html, ' html ');
+        expect(minified).toBe('<div>test</div>');
+    });
+
+    test('should handle invalid HTML', async () => {
+        const invalidHtml = '<div unclosed tag';
+        const minified = await minifyContents(invalidHtml, 'html');
+        expect(typeof minified).toBe('string');
+    });
+});

--- a/src/minify/minifyContents.spec.ts
+++ b/src/minify/minifyContents.spec.ts
@@ -27,13 +27,11 @@ describe('minifyContents', () => {
         const minified = await minifyContents(html, 'html');
 
         // Basic checks for minification
-        expect(minified.includes('  Hello   World  ')).toBe(false);
-        expect(minified.includes('Hello World')).toBe(true);
-        expect(minified.includes('\n')).toBe(false);
-        expect(minified.includes('<!doctype html>')).toBe(true); // @minify-html usually lowercases doctype
-    });
-
-    test('should return original content if fileType is not html', async () => {
+        expect(minified).not.toContain('  Hello   World  ');
+        expect(minified).toContain('Hello World');
+        expect(minified).not.toContain('\n');
+        expect(minified).toContain('<!doctype html>'); // @minify-html usually lowercases doctype
+    }); test('should return original content if fileType is not html', async () => {
         const css = `
             body {
                 color: red;


### PR DESCRIPTION
This pull request updates the development environment and testing framework to use more recent versions of Node.js and TypeScript, enhances the custom test framework with new assertions, and adds comprehensive tests for the HTML minification logic. The changes improve compatibility, add useful test utilities, and increase test coverage.

**Dependency and environment updates:**

- Updated the supported Node.js versions in the GitHub Actions workflow to only include 20, 22, and 24, dropping support for Node.js 18. (`.github/workflows/dev.yml`)
- Upgraded the `typescript` dependency from version 3.9.10 to 5.9.3 in both the root and `simple-test-framework` package, and updated the minimum Node.js engine requirement to 20.0.0 in the root `package.json`. (`local_modules/simple-test-framework/package.json`, `local_modules/simple-test-framework/package-lock.json`, `package.json`) [[1]](diffhunk://#diff-25a45950be93fd5c15ee3d719b3a8507584c6793cb2eb40072b88602edcd3c79L14-R14) [[2]](diffhunk://#diff-dfda462ca90816b2259284e033afd7e83326bee1a91c332b36c525fc55af5229L14-R15) [[3]](diffhunk://#diff-dfda462ca90816b2259284e033afd7e83326bee1a91c332b36c525fc55af5229L200-R219) [[4]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L62-R69)

**Testing framework improvements:**

- Added new assertion methods `toContain` and `not.toContain` to the `expect` API in `simple-test-framework`, allowing for more expressive tests involving arrays and strings. (`local_modules/simple-test-framework/src/index.ts`)

**Test coverage:**

- Added a new test suite for the `minifyContents` function, covering HTML minification, non-HTML passthrough, case and whitespace handling in file types, and robustness against invalid HTML. (`src/minify/minifyContents.spec.ts`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added new assertion methods to the test framework: `toContain()` for validating array and string elements, `not.toContain()` for negated containment checks, and `not.toBe()` for inequality assertions.

* **Chores**
  * Updated minimum Node.js requirement from 18 to 20.
  * Updated TypeScript and tooling dependencies.
  * Added comprehensive test coverage for content minification.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->